### PR TITLE
Fix code scanning alert no. 41: Incomplete string escaping or encoding

### DIFF
--- a/lib/scraper2.js
+++ b/lib/scraper2.js
@@ -932,7 +932,7 @@ exports.gempa = async () => {
 				const drasa = [];
 				$('table > tbody > tr:nth-child(1) > td:nth-child(6) > span').get().map((rest) => {
 					dir = $(rest).text();
-					drasa.push(dir.replace('\t', ' '))
+					drasa.push(dir.replace(/\t/g, ' '))
 				})
 				teks = ''
 				for (let i = 0; i < drasa.length; i++) {


### PR DESCRIPTION
Fixes [https://github.com/Dark-Xploit/XPLOADER-BOT/security/code-scanning/41](https://github.com/Dark-Xploit/XPLOADER-BOT/security/code-scanning/41)

To fix the problem, we need to ensure that all occurrences of the tab character (`\t`) are replaced with a space. This can be achieved by using a regular expression with the global flag (`g`). The `replace` method should be updated to use a regular expression instead of a string as the first argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
